### PR TITLE
Add admin portal templates and detail views

### DIFF
--- a/backend_portal/fleet_manager/portal/templates/portal/base.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/base.html
@@ -1,0 +1,82 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" href="{% static 'assets/images/favicon.png' %}" type="image/png" />
+    <title>{% block title %}Fleet Manager Admin{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="{% static 'assets/css/vendors/bootstrap.css' %}" />
+    <link rel="stylesheet" href="{% static 'assets/css/vendors/feather-icon.css' %}" />
+    <link rel="stylesheet" href="{% static 'assets/css/font-awesome.css' %}" />
+    <link rel="stylesheet" href="{% static 'assets/css/style.css' %}" />
+    <link id="color" rel="stylesheet" href="{% static 'assets/css/color-1.css' %}" />
+    <link rel="stylesheet" href="{% static 'assets/css/responsive.css' %}" />
+    {% block head_extra %}{% endblock %}
+    <style>
+      .page-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:1rem}
+      .content-wrapper{padding:20px}
+      .table-actions a{margin-right:.5rem}
+      .card-hover:hover{box-shadow:0 0.5rem 1rem rgba(0,0,0,.1)}
+      .form-card{max-width:900px;margin:0 auto}
+    </style>
+  </head>
+  <body>
+    <div class="page-wrapper compact-wrapper" id="pageWrapper">
+      <div class="page-header">
+        <div class="header-wrapper row m-0">
+          <div class="logo-wrapper col-auto p-2">
+            <a href="{% url 'portal-admin' %}">
+              <img class="img-fluid for-dark" src="{% static 'assets/images/logo/logo.png' %}" alt="logo" />
+              <img class="img-fluid for-light" src="{% static 'assets/images/logo/logo_dark.png' %}" alt="logo" />
+            </a>
+          </div>
+          <div class="col d-flex align-items-center">
+            <h5 class="mb-0">Fleet Manager Admin</h5>
+          </div>
+          <div class="col-auto p-2">
+            <a class="btn btn-outline-primary" href="{% url 'logout' %}">Sign out</a>
+          </div>
+        </div>
+      </div>
+
+      <div class="page-body-wrapper">
+        <div class="sidebar-wrapper">
+          <div>
+            <div class="logo-wrapper"><a href="{% url 'portal-admin' %}"><img class="img-fluid for-dark" src="{% static 'assets/images/logo/logo.png' %}" alt="" /></a></div>
+            <nav class="sidebar-main">
+              <ul class="sidebar-links" id="simple-bar">
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-admin' %}"><i data-feather="home"></i><span>Overview</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-customers' %}"><i data-feather="users"></i><span>Customers</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-vehicles' %}"><i data-feather="truck"></i><span>Vehicles</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-inspectors' %}"><i data-feather="user-check"></i><span>Inspectors</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-assignments' %}"><i data-feather="calendar"></i><span>Assignments</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-inspections' %}"><i data-feather="clipboard"></i><span>Inspections</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-vehicle-catalog' %}"><i data-feather="layers"></i><span>Vehicle Catalog</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-categories' %}"><i data-feather="list"></i><span>Checklist</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-users' %}"><i data-feather="shield"></i><span>Users</span></a></li>
+                <li class="sidebar-list"><a class="sidebar-link" href="{% url 'portal-reports' %}"><i data-feather="bar-chart-2"></i><span>Reports</span></a></li>
+              </ul>
+            </nav>
+          </div>
+        </div>
+
+        <div class="page-body">
+          <div class="container-fluid content-wrapper">
+            {% block content %}{% endblock %}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <script src="{% static 'assets/js/jquery.min.js' %}"></script>
+    <script src="{% static 'assets/js/bootstrap/bootstrap.bundle.min.js' %}"></script>
+    <script src="{% static 'assets/js/icons/feather-icon/feather.min.js' %}"></script>
+    <script src="{% static 'assets/js/icons/feather-icon/feather-icon.js' %}"></script>
+    <script src="{% static 'assets/js/script.js' %}"></script>
+    {% block body_extra %}{% endblock %}
+  </body>
+</html>

--- a/backend_portal/fleet_manager/portal/templates/portal/dashboard-02.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/dashboard-02.html
@@ -1,0 +1,108 @@
+{% extends 'portal/base.html' %}
+{% block title %}Dashboard · Fleet Manager{% endblock %}
+{% block content %}
+<div class="row g-3">
+  <div class="col-12"><h3>Overview</h3></div>
+  <div class="col-md-3">
+    <div class="card card-hover">
+      <div class="card-body">
+        <h6 class="mb-1">Customers</h6>
+        <h3 class="mb-0">{{ kpi_customers }}</h3>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card card-hover">
+      <div class="card-body">
+        <h6 class="mb-1">Vehicles</h6>
+        <h3 class="mb-0">{{ kpi_vehicles }}</h3>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card card-hover">
+      <div class="card-body">
+        <h6 class="mb-1">Inspectors</h6>
+        <h3 class="mb-0">{{ kpi_inspectors }}</h3>
+      </div>
+    </div>
+  </div>
+  <div class="col-md-3">
+    <div class="card card-hover">
+      <div class="card-body">
+        <h6 class="mb-1">Inspections</h6>
+        <h3 class="mb-0">{{ kpi_inspections }}</h3>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="row g-3 mt-2">
+  <div class="col-lg-8">
+    <div class="card h-100">
+      <div class="card-header d-flex align-items-center justify-content-between">
+        <h5 class="mb-0">Recent Inspections</h5>
+        <a href="{% url 'portal-inspections' %}" class="btn btn-sm btn-outline-primary">View all</a>
+      </div>
+      <div class="card-body pt-0">
+        <div class="input-group my-3">
+          <span class="input-group-text"><i data-feather="search"></i></span>
+          <input id="recentSearch" class="form-control" type="search" placeholder="Search by license plate" />
+        </div>
+        <div id="recentInspections">
+          {% include 'portal/partials/recent_inspections_table.html' with recent_inspections=recent_inspections %}
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-4">
+    <div class="card mb-3">
+      <div class="card-header"><h5 class="mb-0">Upcoming Assignments</h5></div>
+      <div class="card-body p-0">
+        <ul class="list-group list-group-flush">
+          {% for a in upcoming_assignments %}
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <div>
+                <div class="fw-semibold">{{ a.vehicle.license_plate }} · {{ a.vehicle.customer.legal_name }}</div>
+                <small class="text-muted">{{ a.inspector.profile.user.get_full_name|default:a.inspector.profile.user.username }}</small>
+              </div>
+              <span class="badge bg-primary">{{ a.scheduled_for }}</span>
+            </li>
+          {% empty %}
+            <li class="list-group-item text-center text-muted">No upcoming assignments</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header"><h5 class="mb-0">New Customers</h5></div>
+      <ul class="list-group list-group-flush">
+        {% for c in recent_customers %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <a href="{% url 'portal-customer-detail' c.id %}">{{ c.legal_name }}</a>
+            <small class="text-muted">{{ c.city }}</small>
+          </li>
+        {% empty %}
+          <li class="list-group-item text-center text-muted">No recent customers</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block body_extra %}
+<script>
+(function(){
+  const input = document.getElementById('recentSearch');
+  if(!input) return;
+  let t; input.addEventListener('input', function(){
+    clearTimeout(t);
+    t = setTimeout(() => {
+      const q = encodeURIComponent(input.value || '');
+      fetch('{% url 'portal-recent-inspections-partial' %}?q=' + q, {headers: {'X-Requested-With':'XMLHttpRequest','HX-Request':'true'}})
+        .then(r => r.text()).then(html => { document.getElementById('recentInspections').innerHTML = html; });
+    }, 250);
+  });
+})();
+</script>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/forbidden.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/forbidden.html
@@ -1,0 +1,5 @@
+{% extends 'portal/base.html' %}
+{% block title %}Forbidden{% endblock %}
+{% block content %}
+<div class="alert alert-danger">You do not have permission to access this area.</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/forms/form_page.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/forms/form_page.html
@@ -1,0 +1,33 @@
+{% extends 'portal/base.html' %}
+{% block title %}{{ form_title }} · Fleet Manager{% endblock %}
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-lg-8">
+    <div class="card form-card">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h5 class="mb-0">{{ form_title }}</h5>
+        <a href="{{ cancel_url }}" class="btn btn-sm btn-outline-secondary">Cancel</a>
+      </div>
+      <div class="card-body">
+        <form method="post" action="{{ form_action }}">
+          {% csrf_token %}
+          {% if form.non_field_errors %}
+            <div class="alert alert-danger">{{ form.non_field_errors|join:', ' }}</div>
+          {% endif %}
+          {% for field in form %}
+            <div class="mb-3">
+              <label class="form-label" for="id_{{ field.name }}">{{ field.label }}</label>
+              {{ field }}
+              {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+              {% for error in field.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+            </div>
+          {% endfor %}
+          <div class="d-grid">
+            <button class="btn btn-primary" type="submit">{{ submit_label }}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/forms/form_partial.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/forms/form_partial.html
@@ -1,0 +1,25 @@
+<div class="card form-card">
+  <div class="card-header d-flex justify-content-between align-items-center">
+    <h5 class="mb-0">{{ form_title }}</h5>
+    <a href="{{ cancel_url }}" class="btn btn-sm btn-outline-secondary">Cancel</a>
+  </div>
+  <div class="card-body">
+    <form method="post" action="{{ form_action }}">
+      {% csrf_token %}
+      {% if form.non_field_errors %}
+        <div class="alert alert-danger">{{ form.non_field_errors|join:', ' }}</div>
+      {% endif %}
+      {% for field in form %}
+        <div class="mb-3">
+          <label class="form-label" for="id_{{ field.name }}">{{ field.label }}</label>
+          {{ field }}
+          {% if field.help_text %}<div class="form-text">{{ field.help_text }}</div>{% endif %}
+          {% for error in field.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        </div>
+      {% endfor %}
+      <div class="d-grid">
+        <button class="btn btn-primary" type="submit">{{ submit_label }}</button>
+      </div>
+    </form>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/assignments.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/assignments.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Assignments · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Assignments</h4>
+  <a href="{% url 'portal-assignments-new' %}" class="btn btn-primary">Create Assignment</a>
+</div>
+{% include 'portal/partials/assignments.html' with assignments=assignments %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/categories.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/categories.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Checklist · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Checklist</h4>
+  <a href="{% url 'portal-categories-new' %}" class="btn btn-primary">Add Category</a>
+</div>
+{% include 'portal/partials/categories.html' with categories=categories %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/customer_detail.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/customer_detail.html
@@ -1,0 +1,84 @@
+{% extends 'portal/base.html' %}
+{% block title %}Customer · {{ customer.legal_name }}{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">{{ customer.legal_name }}</h4>
+  <div>
+    <a href="{% url 'portal-customers-edit' customer.id %}" class="btn btn-outline-secondary">Edit</a>
+    <a href="{% url 'portal-customers' %}" class="btn btn-primary">Back</a>
+  </div>
+</div>
+<div class="row g-3">
+  <div class="col-lg-4">
+    <div class="card h-100">
+      <div class="card-header"><h6 class="mb-0">Details</h6></div>
+      <div class="card-body">
+        <div><strong>Email:</strong> {{ customer.contact_email }}</div>
+        {% if customer.contact_phone %}<div><strong>Phone:</strong> {{ customer.contact_phone }}</div>{% endif %}
+        <div class="mt-2"><strong>Address:</strong><br>
+          {{ customer.address_line1 }}<br>
+          {% if customer.address_line2 %}{{ customer.address_line2 }}<br>{% endif %}
+          {{ customer.city }} {{ customer.state }} {{ customer.postal_code }}<br>
+          {{ customer.country }}
+        </div>
+        {% if customer.notes %}<div class="mt-2"><strong>Notes:</strong><br>{{ customer.notes }}</div>{% endif %}
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    <div class="card mb-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h6 class="mb-0">Vehicles</h6>
+        <a href="{% url 'portal-vehicles-new' %}" class="btn btn-sm btn-primary">Add Vehicle</a>
+      </div>
+      <div class="card-body p-0">
+        <table class="table mb-0">
+          <thead><tr><th>Plate</th><th>VIN</th><th>Make/Model</th><th>Year</th></tr></thead>
+          <tbody>
+            {% for v in vehicles %}
+              <tr><td>{{ v.license_plate }}</td><td><small>{{ v.vin }}</small></td><td>{{ v.make }} {{ v.model }}</td><td>{{ v.year }}</td></tr>
+            {% empty %}<tr><td colspan="4" class="text-muted text-center">No vehicles</td></tr>{% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card mb-3">
+      <div class="card-header"><h6 class="mb-0">Recent Inspections</h6></div>
+      <div class="card-body p-0">
+        <table class="table mb-0">
+          <thead><tr><th>Ref</th><th>Vehicle</th><th>Inspector</th><th>Status</th><th></th></tr></thead>
+          <tbody>
+            {% for i in inspections %}
+              <tr>
+                <td><code>{{ i.reference|slice:':8' }}</code></td>
+                <td>{{ i.vehicle.license_plate }}</td>
+                <td>{{ i.inspector.profile.user.get_full_name|default:i.inspector.profile.user.username }}</td>
+                <td>{{ i.get_status_display }}</td>
+                <td class="text-end"><a target="_blank" href="/api/inspections/{{ i.id }}/report_pdf/" class="btn btn-sm btn-outline-primary">Report</a></td>
+              </tr>
+            {% empty %}<tr><td colspan="5" class="text-muted text-center">No inspections</td></tr>{% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header"><h6 class="mb-0">Assignments</h6></div>
+      <div class="card-body p-0">
+        <table class="table mb-0">
+          <thead><tr><th>Vehicle</th><th>Inspector</th><th>Date</th><th>Status</th></tr></thead>
+          <tbody>
+            {% for a in assignments %}
+              <tr>
+                <td>{{ a.vehicle.license_plate }}</td>
+                <td>{{ a.inspector.profile.user.get_full_name|default:a.inspector.profile.user.username }}</td>
+                <td>{{ a.scheduled_for }}</td>
+                <td>{{ a.get_status_display }}</td>
+              </tr>
+            {% empty %}<tr><td colspan="4" class="text-muted text-center">No assignments</td></tr>{% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/customers.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/customers.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Customers · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Customers</h4>
+  <a href="{% url 'portal-customers-new' %}" class="btn btn-primary">Add Customer</a>
+</div>
+{% include 'portal/partials/customers.html' with customers=customers %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/inspections.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/inspections.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Inspections · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Inspections</h4>
+  <a href="{% url 'portal-inspections-new' %}" class="btn btn-primary">Log Inspection</a>
+</div>
+{% include 'portal/partials/inspections.html' with inspections=inspections %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/inspector_detail.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/inspector_detail.html
@@ -1,0 +1,62 @@
+{% extends 'portal/base.html' %}
+{% block title %}Inspector · {{ inspector.profile.user.get_full_name|default:inspector.profile.user.username }}{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">{{ inspector.profile.user.get_full_name|default:inspector.profile.user.username }}</h4>
+  <div>
+    <a href="{% url 'portal-inspectors-edit' inspector.id %}" class="btn btn-outline-secondary">Edit</a>
+    <a href="{% url 'portal-inspectors' %}" class="btn btn-primary">Back</a>
+  </div>
+</div>
+<div class="row g-3">
+  <div class="col-lg-4">
+    <div class="card h-100">
+      <div class="card-header"><h6 class="mb-0">Profile</h6></div>
+      <div class="card-body">
+        <div><strong>Badge:</strong> {{ inspector.badge_id }}</div>
+        <div><strong>Status:</strong> {% if inspector.is_active %}Active{% else %}Inactive{% endif %}</div>
+        <div class="mt-2"><strong>Certifications</strong><div style="white-space:pre-line">{{ inspector.certifications|default:'—' }}</div></div>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    <div class="card mb-3">
+      <div class="card-header"><h6 class="mb-0">Assignments</h6></div>
+      <div class="card-body p-0">
+        <table class="table mb-0">
+          <thead><tr><th>Vehicle</th><th>Customer</th><th>Date</th><th>Status</th></tr></thead>
+          <tbody>
+            {% for a in assignments %}
+              <tr>
+                <td>{{ a.vehicle.license_plate }}</td>
+                <td>{{ a.vehicle.customer.legal_name }}</td>
+                <td>{{ a.scheduled_for }}</td>
+                <td>{{ a.get_status_display }}</td>
+              </tr>
+            {% empty %}<tr><td colspan="4" class="text-muted text-center">No assignments</td></tr>{% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header"><h6 class="mb-0">Recent Inspections</h6></div>
+      <div class="card-body p-0">
+        <table class="table mb-0">
+          <thead><tr><th>Ref</th><th>Vehicle</th><th>Customer</th><th>Status</th><th></th></tr></thead>
+          <tbody>
+            {% for i in inspections %}
+              <tr>
+                <td><code>{{ i.reference|slice:':8' }}</code></td>
+                <td>{{ i.vehicle.license_plate }}</td>
+                <td>{{ i.customer.legal_name }}</td>
+                <td>{{ i.get_status_display }}</td>
+                <td class="text-end"><a target="_blank" href="/api/inspections/{{ i.id }}/report_pdf/" class="btn btn-sm btn-outline-primary">Report</a></td>
+              </tr>
+            {% empty %}<tr><td colspan="5" class="text-muted text-center">No inspections</td></tr>{% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/inspectors.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/inspectors.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Inspectors · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Inspectors</h4>
+  <a href="{% url 'portal-inspectors-new' %}" class="btn btn-primary">Add Inspector</a>
+</div>
+{% include 'portal/partials/inspectors.html' with inspectors=inspectors %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/reports.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/reports.html
@@ -1,0 +1,34 @@
+{% extends 'portal/base.html' %}
+{% block title %}Reports · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Reports</h4>
+</div>
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>Ref</th><th>Vehicle</th><th>Customer</th><th>Inspector</th><th>Status</th><th>Created</th><th></th></tr></thead>
+        <tbody>
+          {% for i in inspections %}
+            <tr>
+              <td><code>{{ i.reference|slice:':8' }}</code></td>
+              <td>{{ i.vehicle.license_plate }}</td>
+              <td>{{ i.customer.legal_name }}</td>
+              <td>{{ i.inspector.profile.user.get_full_name|default:i.inspector.profile.user.username }}</td>
+              <td><span class="badge bg-light text-dark">{{ i.get_status_display }}</span></td>
+              <td>{{ i.created_at|date:'Y-m-d H:i' }}</td>
+              <td class="text-end table-actions">
+                <a class="btn btn-sm btn-outline-primary" target="_blank" href="/api/inspections/{{ i.id }}/report_pdf/">PDF</a>
+                <a class="btn btn-sm btn-outline-secondary" target="_blank" href="/api/inspections/{{ i.id }}/report/">HTML</a>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="7" class="text-center text-muted">No reports yet</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/users.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/users.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Users · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Users</h4>
+  <a href="{% url 'portal-users-new' %}" class="btn btn-primary">Create User</a>
+</div>
+{% include 'portal/partials/users.html' with users=users %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/vehicle_catalog.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/vehicle_catalog.html
@@ -1,0 +1,12 @@
+{% extends 'portal/base.html' %}
+{% block title %}Vehicle Catalog · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Vehicle Catalog</h4>
+  <div>
+    <a href="{% url 'portal-vehicle-makes-new' %}" class="btn btn-primary">Add Make</a>
+    <a href="{% url 'portal-vehicle-models-new' %}" class="btn btn-outline-primary">Add Model</a>
+  </div>
+</div>
+{% include 'portal/partials/vehicle_catalog.html' with makes=makes %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/vehicles.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/vehicles.html
@@ -1,0 +1,9 @@
+{% extends 'portal/base.html' %}
+{% block title %}Vehicles · Fleet Manager{% endblock %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h4 class="mb-0">Vehicles</h4>
+  <a href="{% url 'portal-vehicles-new' %}" class="btn btn-primary">Add Vehicle</a>
+</div>
+{% include 'portal/partials/vehicles.html' with vehicles=vehicles %}
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/assignments.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/assignments.html
@@ -1,0 +1,27 @@
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>Vehicle</th><th>Inspector</th><th>Date</th><th>Status</th><th></th></tr></thead>
+        <tbody>
+          {% for a in assignments %}
+            <tr>
+              <td>{{ a.vehicle.license_plate }} · {{ a.vehicle.customer.legal_name }}</td>
+              <td><a href="{% url 'portal-inspector-detail' a.inspector.id %}">{{ a.inspector.profile.user.get_full_name|default:a.inspector.profile.user.username }}</a></td>
+              <td>{{ a.scheduled_for }}</td>
+              <td><span class="badge bg-light text-dark">{{ a.get_status_display }}</span></td>
+              <td class="text-end table-actions">
+                <a href="{% url 'portal-assignments-edit' a.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                <form method="post" action="{% url 'portal-assignments-delete' a.id %}" class="d-inline">{% csrf_token %}
+                  <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this assignment?')">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="5" class="text-center text-muted">No assignments found</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/categories.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/categories.html
@@ -1,0 +1,42 @@
+<div class="row g-3">
+  {% for c in categories %}
+  <div class="col-lg-6">
+    <div class="card h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div>
+          <h6 class="mb-0">{{ c.name }}</h6>
+          <small class="text-muted">{{ c.description }}</small>
+        </div>
+        <div>
+          <a href="{% url 'portal-categories-edit' c.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+          <form method="post" action="{% url 'portal-categories-delete' c.id %}" class="d-inline">{% csrf_token %}
+            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this category?')">Delete</button>
+          </form>
+          <a href="{% url 'portal-checklist-items-new' %}?category={{ c.id }}" class="btn btn-sm btn-primary">Add Item</a>
+        </div>
+      </div>
+      <ul class="list-group list-group-flush">
+        {% for item in c.items.all %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div>
+              <div class="fw-semibold">{{ item.title }}</div>
+              <small class="text-muted">{{ item.code }}</small>
+            </div>
+            <div>
+              {% if item.requires_photo %}<span class="badge bg-warning text-dark">Photo Required</span>{% endif %}
+              <a href="{% url 'portal-checklist-items-edit' item.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+              <form method="post" action="{% url 'portal-checklist-items-delete' item.id %}" class="d-inline">{% csrf_token %}
+                <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this item?')">Delete</button>
+              </form>
+            </div>
+          </li>
+        {% empty %}
+          <li class="list-group-item text-muted">No items</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% empty %}
+    <div class="col-12 text-center text-muted">No categories found</div>
+  {% endfor %}
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/customers.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/customers.html
@@ -1,0 +1,26 @@
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>Name</th><th>Contact</th><th>City</th><th></th></tr></thead>
+        <tbody>
+          {% for c in customers %}
+            <tr>
+              <td><a href="{% url 'portal-customer-detail' c.id %}">{{ c.legal_name }}</a></td>
+              <td>{{ c.contact_email }}{% if c.contact_phone %}<br><small class="text-muted">{{ c.contact_phone }}</small>{% endif %}</td>
+              <td>{{ c.city }}</td>
+              <td class="text-end table-actions">
+                <a href="{% url 'portal-customers-edit' c.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                <form method="post" action="{% url 'portal-customers-delete' c.id %}" class="d-inline">{% csrf_token %}
+                  <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this customer?')">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="4" class="text-center text-muted">No customers found</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/inspections.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/inspections.html
@@ -1,0 +1,29 @@
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>Ref</th><th>Vehicle</th><th>Inspector</th><th>Status</th><th>Created</th><th></th></tr></thead>
+        <tbody>
+          {% for i in inspections %}
+            <tr>
+              <td><code>{{ i.reference|slice:':8' }}</code></td>
+              <td>{{ i.vehicle.license_plate }} · {{ i.vehicle.customer.legal_name }}</td>
+              <td><a href="{% url 'portal-inspector-detail' i.inspector.id %}">{{ i.inspector.profile.user.get_full_name|default:i.inspector.profile.user.username }}</a></td>
+              <td><span class="badge bg-light text-dark">{{ i.get_status_display }}</span></td>
+              <td>{{ i.created_at|date:'Y-m-d H:i' }}</td>
+              <td class="text-end">
+                <a class="btn btn-sm btn-outline-primary" href="{% url 'inspection-report' i.id %}">View Report</a>
+                <a class="btn btn-sm btn-outline-secondary" href="{% url 'portal-inspections-edit' i.id %}">Edit</a>
+                <form method="post" action="{% url 'portal-inspections-delete' i.id %}" class="d-inline">{% csrf_token %}
+                  <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this inspection?')">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="6" class="text-center text-muted">No inspections found</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/inspectors.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/inspectors.html
@@ -1,0 +1,26 @@
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>Inspector</th><th>Badge</th><th>Status</th><th></th></tr></thead>
+        <tbody>
+          {% for i in inspectors %}
+            <tr>
+              <td><a href="{% url 'portal-inspector-detail' i.id %}">{{ i.profile.user.get_full_name|default:i.profile.user.username }}</a></td>
+              <td>{{ i.badge_id }}</td>
+              <td>{% if i.is_active %}<span class="badge bg-success">Active</span>{% else %}<span class="badge bg-secondary">Inactive</span>{% endif %}</td>
+              <td class="text-end table-actions">
+                <a href="{% url 'portal-inspectors-edit' i.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                <form method="post" action="{% url 'portal-inspectors-delete' i.id %}" class="d-inline">{% csrf_token %}
+                  <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this inspector?')">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="4" class="text-center text-muted">No inspectors found</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/recent_inspections_table.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/recent_inspections_table.html
@@ -1,0 +1,28 @@
+<div class="table-responsive">
+  <table class="table table-striped align-middle">
+    <thead>
+      <tr>
+        <th>Ref</th>
+        <th>Vehicle</th>
+        <th>Customer</th>
+        <th>Inspector</th>
+        <th>Status</th>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for i in recent_inspections %}
+      <tr>
+        <td><code>{{ i.reference|slice:':8' }}</code></td>
+        <td>{{ i.vehicle.license_plate }}</td>
+        <td>{{ i.vehicle.customer.legal_name }}</td>
+        <td>{{ i.inspector.profile.user.get_full_name|default:i.inspector.profile.user.username }}</td>
+        <td><span class="badge bg-light text-dark">{{ i.get_status_display }}</span></td>
+        <td>{{ i.created_at|date:'Y-m-d H:i' }}</td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="6" class="text-center text-muted">No inspections yet</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/users.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/users.html
@@ -1,0 +1,26 @@
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>User</th><th>Role</th><th>Org</th><th></th></tr></thead>
+        <tbody>
+          {% for u in users %}
+            <tr>
+              <td>{{ u.user.get_full_name|default:u.user.username }}<br><small class="text-muted">{{ u.user.email }}</small></td>
+              <td>{{ u.get_role_display }}</td>
+              <td>{{ u.organization }}</td>
+              <td class="text-end table-actions">
+                <a href="{% url 'portal-users-edit' u.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                <form method="post" action="{% url 'portal-users-delete' u.id %}" class="d-inline">{% csrf_token %}
+                  <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this user?')">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="4" class="text-center text-muted">No users found</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/vehicle_catalog.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/vehicle_catalog.html
@@ -1,0 +1,35 @@
+<div class="row g-3">
+  {% for make in makes %}
+  <div class="col-md-6">
+    <div class="card h-100">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h6 class="mb-0">{{ make.name }}</h6>
+        <div>
+          <a href="{% url 'portal-vehicle-models-new' %}?make={{ make.id }}" class="btn btn-sm btn-primary">Add Model</a>
+          <a href="{% url 'portal-vehicle-makes-edit' make.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+          <form method="post" action="{% url 'portal-vehicle-makes-delete' make.id %}" class="d-inline">{% csrf_token %}
+            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this make?')">Delete</button>
+          </form>
+        </div>
+      </div>
+      <ul class="list-group list-group-flush">
+        {% for m in make.models.all %}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div>{{ m.name }}</div>
+            <div>
+              <a href="{% url 'portal-vehicle-models-edit' m.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+              <form method="post" action="{% url 'portal-vehicle-models-delete' m.id %}" class="d-inline">{% csrf_token %}
+                <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this model?')">Delete</button>
+              </form>
+            </div>
+          </li>
+        {% empty %}
+          <li class="list-group-item text-muted">No models</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% empty %}
+    <div class="col-12 text-center text-muted">No makes found</div>
+  {% endfor %}
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/vehicles.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/vehicles.html
@@ -1,0 +1,28 @@
+<div class="card">
+  <div class="card-body p-0">
+    <div class="table-responsive">
+      <table class="table table-hover align-middle mb-0">
+        <thead><tr><th>Plate</th><th>VIN</th><th>Customer</th><th>Make/Model</th><th>Year</th><th></th></tr></thead>
+        <tbody>
+          {% for v in vehicles %}
+            <tr>
+              <td>{{ v.license_plate }}</td>
+              <td><small>{{ v.vin }}</small></td>
+              <td><a href="{% url 'portal-customer-detail' v.customer.id %}">{{ v.customer.legal_name }}</a></td>
+              <td>{{ v.make }} {{ v.model }}</td>
+              <td>{{ v.year }}</td>
+              <td class="text-end table-actions">
+                <a href="{% url 'portal-vehicles-edit' v.id %}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                <form method="post" action="{% url 'portal-vehicles-delete' v.id %}" class="d-inline">{% csrf_token %}
+                  <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Delete this vehicle?')">Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% empty %}
+            <tr><td colspan="6" class="text-center text-muted">No vehicles found</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/backend_portal/fleet_manager/portal/templates/portal/reports/report_customer.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/reports/report_customer.html
@@ -1,0 +1,1 @@
+{% extends 'portal/reports/report_full.html' %}

--- a/backend_portal/fleet_manager/portal/templates/portal/reports/report_full.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/reports/report_full.html
@@ -1,0 +1,53 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="{% static 'assets/css/vendors/bootstrap.css' %}">
+  <style>
+    body{font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;padding:20px}
+    .title{display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem}
+    .badge{padding:.35rem .5rem;border:1px solid #ddd;border-radius:.25rem}
+    .table{width:100%;border-collapse:collapse}
+    .table th,.table td{border:1px solid #e9ecef;padding:.5rem}
+  </style>
+</head>
+<body>
+  <div class="title">
+    <h3>Inspection Report</h3>
+    <span class="badge">Ref: {{ inspection.reference }}</span>
+  </div>
+  <p><strong>Customer:</strong> {{ inspection.customer.legal_name }}<br>
+     <strong>Vehicle:</strong> {{ inspection.vehicle.license_plate }} · {{ inspection.vehicle.make }} {{ inspection.vehicle.model }} ({{ inspection.vehicle.year }})<br>
+     <strong>Inspector:</strong> {{ inspection.inspector.profile.user.get_full_name|default:inspection.inspector.profile.user.username }}<br>
+     <strong>Status:</strong> {{ inspection.get_status_display }}
+  </p>
+  <hr>
+  <h5>Findings</h5>
+  <table class="table">
+    <thead><tr><th>Category</th><th>Item</th><th>Result</th><th>Severity</th><th>Notes</th></tr></thead>
+    <tbody>
+      {% for r in responses %}
+        <tr>
+          <td>{{ r.checklist_item.category.name }}</td>
+          <td>{{ r.checklist_item.title }}</td>
+          <td>{{ r.get_result_display }}</td>
+          <td>{{ r.severity }}</td>
+          <td>{{ r.notes }}</td>
+        </tr>
+      {% empty %}
+        <tr><td colspan="5">No findings recorded.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if inspection.customer_report %}
+    <hr>
+    <h5>Summary</h5>
+    <p style="white-space:pre-line">{{ inspection.customer_report.summary }}</p>
+    {% if inspection.customer_report.recommended_actions %}
+      <h6>Recommended Actions</h6>
+      <p style="white-space:pre-line">{{ inspection.customer_report.recommended_actions }}</p>
+    {% endif %}
+  {% endif %}
+</body>
+</html>

--- a/backend_portal/fleet_manager/portal/urls.py
+++ b/backend_portal/fleet_manager/portal/urls.py
@@ -14,7 +14,7 @@ from .views import (
     VehicleMakeViewSet,
     VehicleModelNameViewSet,
 )
-from . import views_web
+from . import views_web, views_extra
 
 router = DefaultRouter()
 router.register(r'customers', CustomerViewSet, basename='customer')

--- a/backend_portal/fleet_manager/portal/urls.py
+++ b/backend_portal/fleet_manager/portal/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('app/', views_web.app_shell, name='portal-app'),
     path('app/customers/', views_web.customers_view, name='portal-customers'),
     path('app/customers/new/', views_web.customer_create, name='portal-customers-new'),
+    path('app/customers/<int:pk>/', views_extra.customer_detail, name='portal-customer-detail'),
     path('app/customers/<int:pk>/edit/', views_web.customer_edit, name='portal-customers-edit'),
     path('app/customers/<int:pk>/delete/', views_web.customer_delete, name='portal-customers-delete'),
 

--- a/backend_portal/fleet_manager/portal/urls.py
+++ b/backend_portal/fleet_manager/portal/urls.py
@@ -56,6 +56,7 @@ urlpatterns = [
 
     path('app/inspectors/', views_web.inspectors_view, name='portal-inspectors'),
     path('app/inspectors/new/', views_web.inspector_create, name='portal-inspectors-new'),
+    path('app/inspectors/<int:pk>/', views_extra.inspector_detail, name='portal-inspector-detail'),
     path('app/inspectors/<int:pk>/edit/', views_web.inspector_edit, name='portal-inspectors-edit'),
     path('app/inspectors/<int:pk>/delete/', views_web.inspector_delete, name='portal-inspectors-delete'),
 

--- a/backend_portal/fleet_manager/portal/urls.py
+++ b/backend_portal/fleet_manager/portal/urls.py
@@ -70,6 +70,8 @@ urlpatterns = [
     path('app/inspections/<int:pk>/edit/', views_web.inspection_edit, name='portal-inspections-edit'),
     path('app/inspections/<int:pk>/delete/', views_web.inspection_delete, name='portal-inspections-delete'),
 
+    path('app/reports/', views_extra.reports_view, name='portal-reports'),
+
     path('app/categories/', views_web.categories_view, name='portal-categories'),
     path('app/categories/new/', views_web.category_create, name='portal-categories-new'),
     path('app/categories/<int:pk>/edit/', views_web.category_edit, name='portal-categories-edit'),

--- a/backend_portal/fleet_manager/portal/views_extra.py
+++ b/backend_portal/fleet_manager/portal/views_extra.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, render
+
+from .models import Customer, Inspection, InspectorProfile, VehicleAssignment
+from .views_web import _require_admin
+
+
+@login_required
+def reports_view(request: HttpRequest) -> HttpResponse:
+    profile = _require_admin(request)
+    if not profile:
+        return render(request, "portal/forbidden.html", status=403)
+    inspections = (
+        Inspection.objects.select_related(
+            "vehicle",
+            "customer",
+            "inspector",
+            "inspector__profile",
+            "inspector__profile__user",
+        ).order_by("-created_at")[:200]
+    )
+    return render(request, "portal/pages/reports.html", {"profile": profile, "inspections": inspections, "active_tab": "reports"})
+
+
+@login_required
+def customer_detail(request: HttpRequest, pk: int) -> HttpResponse:
+    profile = _require_admin(request)
+    if not profile:
+        return render(request, "portal/forbidden.html", status=403)
+    customer = get_object_or_404(Customer.objects.select_related("profile", "profile__user"), pk=pk)
+    vehicles = customer.vehicles.all().order_by("license_plate")
+    inspections = (
+        Inspection.objects.select_related("vehicle", "inspector", "inspector__profile", "inspector__profile__user")
+        .filter(customer=customer)
+        .order_by("-created_at")[:100]
+    )
+    assignments = (
+        VehicleAssignment.objects.select_related("vehicle", "inspector", "inspector__profile", "inspector__profile__user")
+        .filter(vehicle__customer=customer)
+        .order_by("-scheduled_for")[:100]
+    )
+    context = {
+        "profile": profile,
+        "customer": customer,
+        "vehicles": vehicles,
+        "inspections": inspections,
+        "assignments": assignments,
+        "active_tab": "customers",
+    }
+    return render(request, "portal/pages/customer_detail.html", context)
+
+
+@login_required
+def inspector_detail(request: HttpRequest, pk: int) -> HttpResponse:
+    profile = _require_admin(request)
+    if not profile:
+        return render(request, "portal/forbidden.html", status=403)
+    inspector = get_object_or_404(InspectorProfile.objects.select_related("profile", "profile__user"), pk=pk)
+    assignments = (
+        VehicleAssignment.objects.select_related("vehicle", "vehicle__customer")
+        .filter(inspector=inspector)
+        .order_by("-scheduled_for")[:100]
+    )
+    inspections = (
+        Inspection.objects.select_related("vehicle", "customer")
+        .filter(inspector=inspector)
+        .order_by("-created_at")[:100]
+    )
+    context = {
+        "profile": profile,
+        "inspector": inspector,
+        "assignments": assignments,
+        "inspections": inspections,
+        "active_tab": "inspectors",
+    }
+    return render(request, "portal/pages/inspector_detail.html", context)


### PR DESCRIPTION
## Purpose
The user requested implementation of an attractive, well-organized admin portal for managing fleet operations. They wanted a page-based web portal (not HTMX-dependent) with centered, attractive forms and comprehensive management capabilities including customer and inspector detail tracking pages, reports functionality, and overall process management.

## Code changes
- **Base template**: Added `portal/base.html` with responsive layout, sidebar navigation, and Bootstrap styling
- **Dashboard**: Created `dashboard-02.html` with KPI cards, recent inspections table with search, and upcoming assignments
- **Detail views**: Implemented customer and inspector detail pages with comprehensive tracking information
- **Reports**: Added report templates including full inspection reports with findings and summaries
- **Partial templates**: Created reusable components for vehicles, makes, and other data tables
- **URL routing**: Extended URL patterns to support new detail views and reports functionality
- **Views**: Added `views_extra.py` with customer_detail, inspector_detail, and reports_view functions
- **Styling**: Integrated modern UI with Feather icons, hover effects, and responsive design

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8356a1c8a9474ced94c8bc751be8b09e/swoosh-forge)

👀 [Preview Link](https://8356a1c8a9474ced94c8bc751be8b09e-swoosh-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8356a1c8a9474ced94c8bc751be8b09e</projectId>-->
<!--<branchName>swoosh-forge</branchName>-->